### PR TITLE
Feature/#1 report UI

### DIFF
--- a/src/app/report/history/page.tsx
+++ b/src/app/report/history/page.tsx
@@ -1,0 +1,52 @@
+import ReportPreview from '@/features/report/components/reportPreview';
+import PageHeader from '@/shared/components/ui/pageHeader';
+import SearchInput from '@/shared/components/ui/searchInput';
+
+const reportMock = [
+  {
+    reportId: 123,
+    title: '1월 분석 리포트',
+    summary: '겉으론 시크한데\n속으론 친구들한테 관심 많은 애',
+    analysis: { frequentWord: '피곤해', mainTopic: '학교', mainEmotion: '피곤함' },
+    createdAt: '2025-01-10T14:30:00Z',
+  },
+  {
+    reportId: 124,
+    title: '2월 분석 리포트',
+    summary: '겉으론 시크한데\n속으론 친구들한테 관심 많은 애',
+    analysis: { frequentWord: '귀찮다', mainTopic: '공부', mainEmotion: '지루함' },
+    createdAt: '2025-02-10T14:30:00Z',
+  },
+  {
+    reportId: 125,
+    title: '3월 분석 리포트',
+    summary: '겉으론 시크한데\n속으론 친구들한테 관심 많은 애',
+    analysis: { frequentWord: '어떡해', mainTopic: '숙제', mainEmotion: '두려움' },
+    createdAt: '2025-03-10T14:30:00Z',
+  },
+];
+
+const ChatHistory = () => {
+  return (
+    <div className="gap-xl pt-4xl flex h-full w-full flex-col px-4 md:px-8 lg:px-[7.5rem]">
+      <div className="mt-lg flex w-full flex-row justify-between">
+        <PageHeader title="친구가 보는 나 리포트" />
+        <SearchInput />
+      </div>
+      <div className="gap-base grid h-full grid-cols-1 md:grid-cols-2 lg:grid-cols-3">
+        {reportMock.map((item) => (
+          <ReportPreview
+            key={item.reportId}
+            reportId={item.reportId}
+            title={item.title}
+            summary={item.summary}
+            analysis={item.analysis}
+            createdAt={item.createdAt}
+          />
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default ChatHistory;

--- a/src/features/report/components/reportPreview.tsx
+++ b/src/features/report/components/reportPreview.tsx
@@ -1,0 +1,52 @@
+import { formatDate } from '@/shared/utils/date';
+import Image from 'next/image';
+
+interface reportPreviewProps {
+  reportId: number;
+  title: string;
+  summary: string;
+  analysis: {
+    frequentWord: string;
+    mainTopic: string;
+    mainEmotion: string;
+  };
+  createdAt: string;
+}
+
+const ReportPreview = ({ reportId, title, summary, analysis, createdAt }: reportPreviewProps) => {
+  const date = formatDate(createdAt);
+  return (
+    <div className="p-lg gap-base flex flex-col rounded-md border border-gray-300 bg-white">
+      <div className="gap-xs flex flex-col">
+        <p className="font-regular font-sans text-xs text-gray-400">{date}</p>
+        <h2 className="font-sans text-lg font-semibold text-gray-800">{title}</h2>
+      </div>
+      <div className="bg-primary-300 border-primary-700 p-base gap-sm flex flex-col rounded-lg border-l-2">
+        <p className="font-sans text-sm font-medium text-gray-600">친구들이 보는 너는</p>
+        <Image src="/icon/quotes.svg" alt="따옴표 아이콘" width={24} height={24} />
+        <h3 className="text-md font-sans font-semibold whitespace-pre-line text-gray-700">
+          {summary}
+        </h3>
+      </div>
+      <div className="gap-xs flex flex-col">
+        <div className="itmes-center flex flex-row justify-between">
+          <p className="font-sans text-sm font-medium text-gray-600">가장 많이 쓴 단어</p>
+          <p className="font-sans text-sm font-medium text-gray-700">{analysis.frequentWord}</p>
+        </div>
+        <div className="itmes-center flex flex-row justify-between">
+          <p className="font-sans text-sm font-medium text-gray-600">주요 감정</p>
+          <p className="font-sans text-sm font-medium text-gray-700">{analysis.mainEmotion}</p>
+        </div>
+        <div className="itmes-center flex flex-row justify-between">
+          <p className="font-sans text-sm font-medium text-gray-600">주요 대화 주제</p>
+          <p className="font-sans text-sm font-medium text-gray-700">{analysis.mainTopic}</p>
+        </div>
+      </div>
+      <button className="text-md text-primary-700 cursor-pointer font-sans underline hover:brightness-90">
+        자세히 보기
+      </button>
+    </div>
+  );
+};
+
+export default ReportPreview;

--- a/src/features/report/components/reportPreview.tsx
+++ b/src/features/report/components/reportPreview.tsx
@@ -1,5 +1,6 @@
 import { formatDate } from '@/shared/utils/date';
 import Image from 'next/image';
+import Link from 'next/link';
 
 interface reportPreviewProps {
   reportId: number;
@@ -29,22 +30,25 @@ const ReportPreview = ({ reportId, title, summary, analysis, createdAt }: report
         </h3>
       </div>
       <div className="gap-xs flex flex-col">
-        <div className="itmes-center flex flex-row justify-between">
+        <div className="flex flex-row items-center justify-between">
           <p className="font-sans text-sm font-medium text-gray-600">가장 많이 쓴 단어</p>
           <p className="font-sans text-sm font-medium text-gray-700">{analysis.frequentWord}</p>
         </div>
-        <div className="itmes-center flex flex-row justify-between">
+        <div className="flex flex-row items-center justify-between">
           <p className="font-sans text-sm font-medium text-gray-600">주요 감정</p>
           <p className="font-sans text-sm font-medium text-gray-700">{analysis.mainEmotion}</p>
         </div>
-        <div className="itmes-center flex flex-row justify-between">
+        <div className="flex flex-row items-center justify-between">
           <p className="font-sans text-sm font-medium text-gray-600">주요 대화 주제</p>
           <p className="font-sans text-sm font-medium text-gray-700">{analysis.mainTopic}</p>
         </div>
       </div>
-      <button className="text-md text-primary-700 cursor-pointer font-sans underline hover:brightness-90">
+      <Link
+        href={`/report?id=${reportId}`}
+        className="text-md text-primary-700 w-full cursor-pointer text-center font-sans underline hover:brightness-90"
+      >
         자세히 보기
-      </button>
+      </Link>
     </div>
   );
 };

--- a/src/shared/utils/date.ts
+++ b/src/shared/utils/date.ts
@@ -21,3 +21,8 @@ export const getTimeAgo = (date: string) => {
   const d = new Date(date);
   return `${d.getFullYear()}년 ${d.getMonth() + 1}월 ${d.getDate()}일`;
 };
+
+export const formatDate = (date: string) => {
+  const d = new Date(date);
+  return `${d.getFullYear()}. ${String(d.getMonth() + 1).padStart(2, '0')}. ${String(d.getDate()).padStart(2, '0')}`;
+};

--- a/src/shared/utils/date.ts
+++ b/src/shared/utils/date.ts
@@ -24,5 +24,6 @@ export const getTimeAgo = (date: string) => {
 
 export const formatDate = (date: string) => {
   const d = new Date(date);
+  if (isNaN(d.getTime())) return '';
   return `${d.getFullYear()}. ${String(d.getMonth() + 1).padStart(2, '0')}. ${String(d.getDate()).padStart(2, '0')}`;
 };


### PR DESCRIPTION
## 배경 및 개요
친구가 보는 나 리포트 보관함 페이지 퍼블리싱

Resolves: #1

## 📃 작업내용
<img width="2730" height="1870" alt="image" src="https://github.com/user-attachments/assets/1d055a15-1ece-4863-bc90-38528260cc51" />
* 리포트 보관함 페이지 퍼블리싱
* 목데이터 사용
* Link 태그로 리포트 페이지와 연결

## 🔀 변경사항
* 날짜 포맷 유틸함수 추가 `formatDate`
* `ReportPreview` 컴포넌트 생성
* 이외 기존 컴포넌트 재사용

## 🙋‍♂️ 리뷰노트
리포트 페이지에서 쿼리 스트링으로 아이디를 받아 api 보내는 형식으로 생각했는데 구조에 대해 좀 더 고민해봐야할 것 같습니다

## ✅ PR 체크리스트

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [x] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `.env`, `노션`, `README`)
- [ ] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new History page to browse and review all previously generated reports in an organized card-based layout.
  * Each report card displays the creation date, title, summary, and key analysis findings at a glance.
  * Search functionality available to quickly locate specific reports.
  * Click any report card to access its complete detailed analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->